### PR TITLE
feat: Add Bundler monorepo testbed for grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ multi-ecosystem-groups:
   vite:
     schedule:
       interval: "weekly"
-      
+
 updates:
   - package-ecosystem: "bundler" # See documentation for possible values
     directory: "/" # Location of package manifests
@@ -27,3 +27,27 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+
+  # Bundler monorepo grouped updates testing (gems/app-a)
+  - package-ecosystem: "bundler"
+    directory: "/gems/app-a"
+    schedule:
+      interval: "monthly"
+    groups:
+      grouped-bundler-deps:
+        patterns:
+          - "aws*"
+          - "rails"
+        update-types: ["minor", "patch"]
+
+  # Bundler monorepo grouped updates testing (gems/app-b)
+  - package-ecosystem: "bundler"
+    directory: "/gems/app-b"
+    schedule:
+      interval: "monthly"
+    groups:
+      grouped-bundler-deps:
+        patterns:
+          - "aws*"
+          - "rails"
+        update-types: ["minor", "patch"]

--- a/gems/app-a/Gemfile
+++ b/gems/app-a/Gemfile
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+ruby '>= 3.1.0'
+
+# Shared dependencies for grouped updates testing
+# Using intentionally outdated versions to trigger Dependabot updates
+
+# Rails framework (7.0.8.3 is latest 7.0.x)
+gem 'rails', '7.0.4'
+
+# AWS SDK gems (grouped under "aws*" pattern)
+# Latest: aws-sdk-core 3.241.x, aws-sdk-s3 1.213.x, aws-partitions 1.1211.x
+# Using older but compatible versions
+gem 'aws-sdk-core', '3.203.0'
+gem 'aws-sdk-s3', '1.160.0'
+gem 'aws-partitions', '1.950.0'

--- a/gems/app-a/Gemfile.lock
+++ b/gems/app-a/Gemfile.lock
@@ -1,0 +1,201 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actioncable (7.0.4)
+      actionpack (= 7.0.4)
+      activesupport (= 7.0.4)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+    actionmailbox (7.0.4)
+      actionpack (= 7.0.4)
+      activejob (= 7.0.4)
+      activerecord (= 7.0.4)
+      activestorage (= 7.0.4)
+      activesupport (= 7.0.4)
+      mail (>= 2.7.1)
+      net-imap
+      net-pop
+      net-smtp
+    actionmailer (7.0.4)
+      actionpack (= 7.0.4)
+      actionview (= 7.0.4)
+      activejob (= 7.0.4)
+      activesupport (= 7.0.4)
+      mail (~> 2.5, >= 2.5.4)
+      net-imap
+      net-pop
+      net-smtp
+      rails-dom-testing (~> 2.0)
+    actionpack (7.0.4)
+      actionview (= 7.0.4)
+      activesupport (= 7.0.4)
+      rack (~> 2.0, >= 2.2.0)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.2.0)
+    actiontext (7.0.4)
+      actionpack (= 7.0.4)
+      activerecord (= 7.0.4)
+      activestorage (= 7.0.4)
+      activesupport (= 7.0.4)
+      globalid (>= 0.6.0)
+      nokogiri (>= 1.8.5)
+    actionview (7.0.4)
+      activesupport (= 7.0.4)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    activejob (7.0.4)
+      activesupport (= 7.0.4)
+      globalid (>= 0.3.6)
+    activemodel (7.0.4)
+      activesupport (= 7.0.4)
+    activerecord (7.0.4)
+      activemodel (= 7.0.4)
+      activesupport (= 7.0.4)
+    activestorage (7.0.4)
+      actionpack (= 7.0.4)
+      activejob (= 7.0.4)
+      activerecord (= 7.0.4)
+      activesupport (= 7.0.4)
+      marcel (~> 1.0)
+      mini_mime (>= 1.1.0)
+    activesupport (7.0.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.950.0)
+    aws-sdk-core (3.203.0)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.9)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.90.0)
+      aws-sdk-core (~> 3, >= 3.203.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.160.0)
+      aws-sdk-core (~> 3, >= 3.203.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
+    base64 (0.3.0)
+    builder (3.3.0)
+    concurrent-ruby (1.3.6)
+    crass (1.0.6)
+    date (3.5.1)
+    erubi (1.13.1)
+    globalid (1.3.0)
+      activesupport (>= 6.1)
+    i18n (1.14.8)
+      concurrent-ruby (~> 1.0)
+    jmespath (1.6.2)
+    logger (1.7.0)
+    loofah (2.25.0)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
+    mail (2.9.0)
+      logger
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
+    marcel (1.1.0)
+    method_source (1.1.0)
+    mini_mime (1.1.5)
+    minitest (6.0.1)
+      prism (~> 1.5)
+    net-imap (0.6.2)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.2)
+      timeout
+    net-smtp (0.5.1)
+      net-protocol
+    nio4r (2.7.5)
+    nokogiri (1.19.0-aarch64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.0-aarch64-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.0-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.0-arm-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.0-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.0-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.0-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.0-x86_64-linux-musl)
+      racc (~> 1.4)
+    prism (1.9.0)
+    racc (1.8.1)
+    rack (2.2.21)
+    rack-test (2.2.0)
+      rack (>= 1.3)
+    rails (7.0.4)
+      actioncable (= 7.0.4)
+      actionmailbox (= 7.0.4)
+      actionmailer (= 7.0.4)
+      actionpack (= 7.0.4)
+      actiontext (= 7.0.4)
+      actionview (= 7.0.4)
+      activejob (= 7.0.4)
+      activemodel (= 7.0.4)
+      activerecord (= 7.0.4)
+      activestorage (= 7.0.4)
+      activesupport (= 7.0.4)
+      bundler (>= 1.15.0)
+      railties (= 7.0.4)
+    rails-dom-testing (2.3.0)
+      activesupport (>= 5.0.0)
+      minitest
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.6.2)
+      loofah (~> 2.21)
+      nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    railties (7.0.4)
+      actionpack (= 7.0.4)
+      activesupport (= 7.0.4)
+      method_source
+      rake (>= 12.2)
+      thor (~> 1.0)
+      zeitwerk (~> 2.5)
+    rake (13.3.1)
+    thor (1.5.0)
+    timeout (0.6.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    websocket-driver (0.8.0)
+      base64
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+    zeitwerk (2.7.4)
+
+PLATFORMS
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  aws-partitions (= 1.950.0)
+  aws-sdk-core (= 3.203.0)
+  aws-sdk-s3 (= 1.160.0)
+  rails (= 7.0.4)
+
+RUBY VERSION
+   ruby 3.4.7p58
+
+BUNDLED WITH
+   2.6.9

--- a/gems/app-a/main.rb
+++ b/gems/app-a/main.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Minimal Ruby application for Dependabot grouped updates testing
+# This file exists to make the directory a valid Ruby project
+
+require 'aws-sdk-s3'
+
+puts "App A - AWS SDK S3 version: #{Aws::S3::GEM_VERSION}"
+puts "App A - Rails version: #{Rails.version}" if defined?(Rails)

--- a/gems/app-b/Gemfile
+++ b/gems/app-b/Gemfile
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+ruby '>= 3.1.0'
+
+# Shared dependencies for grouped updates testing
+# Using intentionally outdated versions (different from app-a) to trigger Dependabot updates
+
+# Rails framework (7.0.8.3 is latest 7.0.x)
+gem 'rails', '7.0.6'
+
+# AWS SDK gems (grouped under "aws*" pattern)
+# Latest: aws-sdk-core 3.241.x, aws-sdk-s3 1.213.x, aws-partitions 1.1211.x
+# Using older but compatible versions (slightly newer than app-a)
+gem 'aws-sdk-core', '3.210.0'
+gem 'aws-sdk-s3', '1.170.0'
+gem 'aws-partitions', '1.995.0'

--- a/gems/app-b/Gemfile.lock
+++ b/gems/app-b/Gemfile.lock
@@ -1,0 +1,201 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actioncable (7.0.6)
+      actionpack (= 7.0.6)
+      activesupport (= 7.0.6)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+    actionmailbox (7.0.6)
+      actionpack (= 7.0.6)
+      activejob (= 7.0.6)
+      activerecord (= 7.0.6)
+      activestorage (= 7.0.6)
+      activesupport (= 7.0.6)
+      mail (>= 2.7.1)
+      net-imap
+      net-pop
+      net-smtp
+    actionmailer (7.0.6)
+      actionpack (= 7.0.6)
+      actionview (= 7.0.6)
+      activejob (= 7.0.6)
+      activesupport (= 7.0.6)
+      mail (~> 2.5, >= 2.5.4)
+      net-imap
+      net-pop
+      net-smtp
+      rails-dom-testing (~> 2.0)
+    actionpack (7.0.6)
+      actionview (= 7.0.6)
+      activesupport (= 7.0.6)
+      rack (~> 2.0, >= 2.2.4)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.2.0)
+    actiontext (7.0.6)
+      actionpack (= 7.0.6)
+      activerecord (= 7.0.6)
+      activestorage (= 7.0.6)
+      activesupport (= 7.0.6)
+      globalid (>= 0.6.0)
+      nokogiri (>= 1.8.5)
+    actionview (7.0.6)
+      activesupport (= 7.0.6)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    activejob (7.0.6)
+      activesupport (= 7.0.6)
+      globalid (>= 0.3.6)
+    activemodel (7.0.6)
+      activesupport (= 7.0.6)
+    activerecord (7.0.6)
+      activemodel (= 7.0.6)
+      activesupport (= 7.0.6)
+    activestorage (7.0.6)
+      actionpack (= 7.0.6)
+      activejob (= 7.0.6)
+      activerecord (= 7.0.6)
+      activesupport (= 7.0.6)
+      marcel (~> 1.0)
+      mini_mime (>= 1.1.0)
+    activesupport (7.0.6)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.995.0)
+    aws-sdk-core (3.210.0)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.96.0)
+      aws-sdk-core (~> 3, >= 3.210.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.170.0)
+      aws-sdk-core (~> 3, >= 3.210.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
+    base64 (0.3.0)
+    builder (3.3.0)
+    concurrent-ruby (1.3.6)
+    crass (1.0.6)
+    date (3.5.1)
+    erubi (1.13.1)
+    globalid (1.3.0)
+      activesupport (>= 6.1)
+    i18n (1.14.8)
+      concurrent-ruby (~> 1.0)
+    jmespath (1.6.2)
+    logger (1.7.0)
+    loofah (2.25.0)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
+    mail (2.9.0)
+      logger
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
+    marcel (1.1.0)
+    method_source (1.1.0)
+    mini_mime (1.1.5)
+    minitest (6.0.1)
+      prism (~> 1.5)
+    net-imap (0.6.2)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.2)
+      timeout
+    net-smtp (0.5.1)
+      net-protocol
+    nio4r (2.7.5)
+    nokogiri (1.19.0-aarch64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.0-aarch64-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.0-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.0-arm-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.0-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.0-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.0-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.0-x86_64-linux-musl)
+      racc (~> 1.4)
+    prism (1.9.0)
+    racc (1.8.1)
+    rack (2.2.21)
+    rack-test (2.2.0)
+      rack (>= 1.3)
+    rails (7.0.6)
+      actioncable (= 7.0.6)
+      actionmailbox (= 7.0.6)
+      actionmailer (= 7.0.6)
+      actionpack (= 7.0.6)
+      actiontext (= 7.0.6)
+      actionview (= 7.0.6)
+      activejob (= 7.0.6)
+      activemodel (= 7.0.6)
+      activerecord (= 7.0.6)
+      activestorage (= 7.0.6)
+      activesupport (= 7.0.6)
+      bundler (>= 1.15.0)
+      railties (= 7.0.6)
+    rails-dom-testing (2.3.0)
+      activesupport (>= 5.0.0)
+      minitest
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.6.2)
+      loofah (~> 2.21)
+      nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    railties (7.0.6)
+      actionpack (= 7.0.6)
+      activesupport (= 7.0.6)
+      method_source
+      rake (>= 12.2)
+      thor (~> 1.0)
+      zeitwerk (~> 2.5)
+    rake (13.3.1)
+    thor (1.5.0)
+    timeout (0.6.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    websocket-driver (0.8.0)
+      base64
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+    zeitwerk (2.7.4)
+
+PLATFORMS
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  aws-partitions (= 1.995.0)
+  aws-sdk-core (= 3.210.0)
+  aws-sdk-s3 (= 1.170.0)
+  rails (= 7.0.6)
+
+RUBY VERSION
+   ruby 3.4.7p58
+
+BUNDLED WITH
+   2.6.9

--- a/gems/app-b/main.rb
+++ b/gems/app-b/main.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Minimal Ruby application for Dependabot grouped updates testing
+# This file exists to make the directory a valid Ruby project
+
+require 'aws-sdk-s3'
+
+puts "App B - AWS SDK S3 version: #{Aws::S3::GEM_VERSION}"
+puts "App B - Rails version: #{Rails.version}" if defined?(Rails)


### PR DESCRIPTION
## Summary

Adds a Bundler monorepo structure to support "happy path" testing of Dependabot grouped PRs across multiple directories. This creates two Ruby app directories with overlapping dependencies at intentionally different versions to trigger grouped update proposals.

Addresses: https://github.com/github/dependabot-updates/issues/12173

## Changes

### Added
- `gems/app-a/` - Ruby app with rails 7.0.4, aws-sdk-core 3.203.0, aws-sdk-s3 1.160.0
- `gems/app-b/` - Ruby app with rails 7.0.6, aws-sdk-core 3.210.0, aws-sdk-s3 1.170.0
- Each directory includes `Gemfile`, `Gemfile.lock`, and minimal `main.rb`

### Changed
- `.github/dependabot.yml` - Added two new bundler ecosystem entries for `/gems/app-a` and `/gems/app-b` with `grouped-bundler-deps` configuration matching `aws*` and `rails` patterns

## Version Summary

| Gem | app-a | app-b | Latest |
|-----|-------|-------|--------|
| `rails` | 7.0.4 | 7.0.6 | 7.0.10+ |
| `aws-sdk-core` | 3.203.0 | 3.210.0 | 3.241.x |
| `aws-sdk-s3` | 1.160.0 | 1.170.0 | 1.213.x |
| `aws-partitions` | 1.950.0 | 1.995.0 | 1.1211.x |

## Database Changes

None

## Testing

- [x] `bundle install` succeeds in both `gems/app-a` and `gems/app-b`
- [x] Verified gem versions are intentionally outdated to trigger Dependabot updates
- [x] dependabot.yml syntax is valid

## Acceptance Criteria (from issue)

- [x] `.github/dependabot.yml` configures Bundler grouping by dependency name in multiple directories
- [x] At least two Bundler setups with overlapping dependencies
- [x] The repo can be reliably used as a testbed for grouped update PRs using Bundler