### PR TITLE
feat: Add group-by with update-types filter test (npm, multi-dir with glob)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -94,3 +94,18 @@ updates:
     groups:
       per-dependency:
         group-by: dependency-name
+
+  # Test 5: group-by with update-types filter (npm, multi-directory with glob)
+  - package-ecosystem: npm
+    directories:
+      - "/group-by/with-update-types/"
+      - "/group-by/with-update-types/components/*"
+    schedule:
+      interval: weekly
+    groups:
+      non-major-dependencies:
+        group-by: dependency-name
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"

--- a/group-by/with-update-types/README.md
+++ b/group-by/with-update-types/README.md
@@ -1,0 +1,14 @@
+# group-by/with-update-types
+
+Tests `group-by: dependency-name` combined with an `update-types` filter (`minor` + `patch` only).
+
+## Config highlights
+
+- **Directories:** root + `components/*` (glob)
+- **Group rule:** one PR per dependency name, minor/patch version-updates only
+- **Major updates** are excluded from the group and should appear as individual PRs
+
+## Expected Dependabot behaviour
+
+- For each dependency with an available **minor or patch** update, Dependabot opens a **single grouped PR** that bumps that dependency across all three directories where it appears.
+- Any available **major** update is **not** included in the group and instead produces a separate, ungrouped PR.

--- a/group-by/with-update-types/components/button/package.json
+++ b/group-by/with-update-types/components/button/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "component-button",
+  "version": "1.0.0",
+  "description": "Button component – tests group-by with update-types",
+  "dependencies": {
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "classnames": "2.3.0"
+  },
+  "devDependencies": {
+    "typescript": "5.0.2"
+  }
+}

--- a/group-by/with-update-types/components/modal/package.json
+++ b/group-by/with-update-types/components/modal/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "component-modal",
+  "version": "1.0.0",
+  "description": "Modal component – tests group-by with update-types",
+  "dependencies": {
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "focus-trap-react": "10.1.0"
+  },
+  "devDependencies": {
+    "typescript": "5.0.2"
+  }
+}

--- a/group-by/with-update-types/package.json
+++ b/group-by/with-update-types/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "group-by-with-update-types",
+  "version": "1.0.0",
+  "description": "Test group-by dependency-name with update-types filter (npm)",
+  "dependencies": {
+    "express": "4.18.0",
+    "lodash": "4.17.0",
+    "axios": "1.4.0"
+  },
+  "devDependencies": {
+    "eslint": "8.40.0",
+    "prettier": "2.8.0"
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new Dependabot test scenario that combines `group-by: dependency-name` with an `update-types` filter (`minor` + `patch`) across multiple npm directories using a glob pattern.

Related: https://github.com/dependabot/dependabot-core/issues/13284#issuecomment-3941892979

## Changes

### Added
- **Dependabot config** – new `npm` ecosystem entry targeting `/group-by/with-update-types/` and `/group-by/with-update-types/components/*`
- **`group-by/with-update-types/package.json`** – root manifest (express 4.18.0, lodash 4.17.0, axios 1.4.0, eslint 8.40.0, prettier 2.8.0)
- **`group-by/with-update-types/components/button/package.json`** – button component (react 18.2.0, react-dom 18.2.0, classnames 2.3.0, typescript 5.0.2)
- **`group-by/with-update-types/components/modal/package.json`** – modal component (react 18.2.0, react-dom 18.2.0, focus-trap-react 10.1.0, typescript 5.0.2)
- **`group-by/with-update-types/README.md`** – documents expected Dependabot behaviour

## Expected Dependabot behaviour

| Scenario | Expected result |
|---|---|
| Dependency has a minor/patch update | One grouped PR per dependency name, bumping across all directories |
| Dependency has a major update only | Separate, ungrouped PR |

## Notes

- All dependency versions are valid (verified via `npm view`) but intentionally not latest, so Dependabot will have updates to propose.